### PR TITLE
Added method tpqoa.stream_stop()

### DIFF
--- a/tpqoa/tpqoa.py
+++ b/tpqoa/tpqoa.py
@@ -363,9 +363,13 @@ class tpqoa(object):
                             return msgs
                         break
             if self.stop_stream:
+                self.stop_stream = False
                 if ret:
                     return msgs
                 break
+
+    def stop_stream(self):
+        self.stop_stream = True
 
     def _stream_data_failsafe_thread(self, args):
         try:


### PR DESCRIPTION
In the original implementation, after a stream has been sterted with the method tpqoa.stream_start(), there is no way to stop the stream without know the underlying tpqoa class properties, such the flag stop_stream.
It adds the method tpqoa.stream_stop().