### PR TITLE
Fix Pandas >= 2.x compatibility issue in get_history() frequency generation

### DIFF
--- a/tpqoa/tpqoa.py
+++ b/tpqoa/tpqoa.py
@@ -215,7 +215,7 @@ class tpqoa(object):
             multiplier = float("".join(filter(str.isdigit, granularity)))
             if granularity.startswith('S'):
                 # freq = '1h'
-                freq = f"{int(MAX_REQUEST_COUNT * multiplier / float(3600))}H"
+                freq = f"{int(MAX_REQUEST_COUNT * multiplier / float(3600))}h"
             else:
                 # freq = 'D'
                 freq = f"{int(MAX_REQUEST_COUNT * multiplier / float(1440))}D"

--- a/tpqoa/tpqoa.py
+++ b/tpqoa/tpqoa.py
@@ -215,7 +215,8 @@ class tpqoa(object):
             multiplier = float("".join(filter(str.isdigit, granularity)))
             if granularity.startswith('S'):
                 # freq = '1h'
-                freq = f"{int(MAX_REQUEST_COUNT * multiplier / float(3600))}h"
+                # Use lowercase frequency alias "h" for pandas >= 2.x compatibility
+                freq = f"{int(MAX_REQUEST_COUNT * multiplier / float(3600))}h" 
             else:
                 # freq = 'D'
                 freq = f"{int(MAX_REQUEST_COUNT * multiplier / float(1440))}D"


### PR DESCRIPTION
This PR fixes a compatibility issue with Pandas versions >= 2.x when calling get_history with second-based granularity (e.g. "S5").

In newer Pandas versions, uppercase time frequency aliases are no longer accepted when passed to pd.time_date() so the current implementation of batching frequencies into hourly segments when a user requests second-based granularity breaks, resulting in an error:
ValueError: Invalid frequency: 6H.
Failed to parse with error message:
ValueError("Invalid frequency: H. Failed to parse with error message: KeyError('H'). Did you mean h?")

This PR updates this freq string to use a lowercase "h" to be more in line with newer Pandas versions.

No other bugs were noticed beyond fixing this error.